### PR TITLE
Themes: Add categories to theme change intent.

### DIFF
--- a/core/java/android/content/pm/ThemeUtils.java
+++ b/core/java/android/content/pm/ThemeUtils.java
@@ -95,6 +95,8 @@ public class ThemeUtils {
 
     public static final String ACTION_THEME_CHANGED = "org.cyanogenmod.intent.action.THEME_CHANGED";
 
+    public static final String CATEGORY_THEME_COMPONENT_PREFIX = "org.cyanogenmod.intent.category.";
+
     // Actions in manifests which identify legacy icon packs
     public static final String[] sSupportedActions = new String[] {
             "org.adw.launcher.THEMES",

--- a/services/java/com/android/server/ThemeService.java
+++ b/services/java/com/android/server/ThemeService.java
@@ -677,15 +677,10 @@ public class ThemeService extends IThemeService.Stub {
     }
 
     private void broadcastThemeChange(List<String> components) {
-        StringBuilder sb = new StringBuilder();
-        String delimiter = "";
-        for (String comp : components) {
-            sb.append(delimiter);
-            sb.append(comp);
-            delimiter = "|";
-        }
         final Intent intent = new Intent(ThemeUtils.ACTION_THEME_CHANGED);
-        intent.putExtra("components", sb.toString());
+        for (String comp : components) {
+            intent.addCategory(ThemeUtils.CATEGORY_THEME_COMPONENT_PREFIX + comp.toUpperCase());
+        }
         mContext.sendBroadcastAsUser(intent, UserHandle.ALL);
     }
 


### PR DESCRIPTION
The following categories are available:

org.cyanogenmod.intent.category.MODS_HOMESCREEN
org.cyanogenmod.intent.category.MODS_LOCKSCREEN
org.cyanogenmod.intent.category.MODS_ICONS
org.cyanogenmod.intent.category.MODS_FONTS
org.cyanogenmod.intent.category.MODS_BOOTANIM
org.cyanogenmod.intent.category.MODS_NOTIFICATIONS
org.cyanogenmod.intent.category.MODS_ALARMS
org.cyanogenmod.intent.category.MODS_RINGTONES
org.cyanogenmod.intent.category.MODS_OVERLAYS

Change-Id: Ic444278d1d712cb6207bb10574a471524a8fed41
