### PR TITLE
Fix systemui crash on boot

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/SignalClusterTextView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/SignalClusterTextView.java
@@ -67,6 +67,9 @@ public class SignalClusterTextView extends LinearLayout implements
     }
 
     private void updateSignalText() {
+        if (mMobileSignalText == null) {
+            return;
+        }
         if (mAirplaneMode || mDBm == 0) {
             setVisibility(View.GONE);
         } else if (mSignalClusterStyle == SignalClusterView.STYLE_TEXT) {


### PR DESCRIPTION
The process com.android.systemui would crash after phone booting with a
java.lang.NullPointerException when the signal status style is set to text

Change-Id: Ia7b58fa93b8591d0571b90a57a2fe0fe823b3f45
