### PR TITLE
Add new Card Unavailable reason for SIM power down in APM.

### DIFF
--- a/telephony/java/com/android/internal/telephony/MSimConstants.java
+++ b/telephony/java/com/android/internal/telephony/MSimConstants.java
@@ -57,6 +57,7 @@ public class MSimConstants {
     public enum CardUnavailableReason {
         REASON_CARD_REMOVED,
         REASON_RADIO_UNAVAILABLE,
-        REASON_SIM_REFRESH_RESET
+        REASON_SIM_REFRESH_RESET,
+        REASON_APM_SIM_POWER_DOWN
     };
 }


### PR DESCRIPTION
REASON_APM_SIM_POWER_DOWN value added to CardUnavailableReason enum.
This is to indicate card absent event received when SIM is powered
down in APM.

Change-Id: I985e06d629715ebc0489a2fb19e908ab652bfeeb
CRs-Fixed: 661325
