### PR TITLE
Telephony: fix tdsdma asu invalid value

### DIFF
--- a/telephony/java/android/telephony/SignalStrength.java
+++ b/telephony/java/android/telephony/SignalStrength.java
@@ -933,7 +933,7 @@ public class SignalStrength implements Parcelable {
         final int tdScdmaDbm = getTdScdmaDbm();
         int tdScdmaAsuLevel;
 
-        if (tdScdmaDbm == INVALID) tdScdmaAsuLevel = 255;
+        if (tdScdmaDbm == INVALID) tdScdmaAsuLevel = 99;
         else tdScdmaAsuLevel = tdScdmaDbm + 120;
         if (DBG) log("TD-SCDMA Asu level: " + tdScdmaAsuLevel);
         return tdScdmaAsuLevel;


### PR DESCRIPTION
The magic value for invalid asu is "99", not "255". This error is causing the value validity checks to fail incorrectly, fixit.

Change-Id: Ief816eb577ccf371b3c85df1fe9515eb0bfb3f06
