### PR TITLE
SystemUI (MSIM): Add extra vaules for sim state ready

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/MSimNetworkController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/MSimNetworkController.java
@@ -484,7 +484,9 @@ public class MSimNetworkController extends NetworkController {
         if (IccCardConstants.INTENT_VALUE_ICC_ABSENT.equals(stateExtra)) {
             simState = IccCardConstants.State.ABSENT;
         }
-        else if (IccCardConstants.INTENT_VALUE_ICC_READY.equals(stateExtra)) {
+        else if (IccCardConstants.INTENT_VALUE_ICC_READY.equals(stateExtra)
+                || IccCardConstants.INTENT_VALUE_ICC_IMSI.equals(stateExtra)
+                || IccCardConstants.INTENT_VALUE_ICC_LOADED.equals(stateExtra)) {
             simState = IccCardConstants.State.READY;
         }
         else if (IccCardConstants.INTENT_VALUE_ICC_LOCKED.equals(stateExtra)) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkController.java
@@ -569,7 +569,9 @@ public class NetworkController extends BroadcastReceiver implements DemoMode {
         else if (IccCardConstants.INTENT_VALUE_ICC_CARD_IO_ERROR.equals(stateExtra)) {
             mSimState = IccCardConstants.State.CARD_IO_ERROR;
         }
-        else if (IccCardConstants.INTENT_VALUE_ICC_READY.equals(stateExtra)) {
+        else if (IccCardConstants.INTENT_VALUE_ICC_READY.equals(stateExtra)
+                || IccCardConstants.INTENT_VALUE_ICC_IMSI.equals(stateExtra)
+                || IccCardConstants.INTENT_VALUE_ICC_LOADED.equals(stateExtra)) {
             mSimState = IccCardConstants.State.READY;
         }
         else if (IccCardConstants.INTENT_VALUE_ICC_LOCKED.equals(stateExtra)) {


### PR DESCRIPTION
From: https://www.codeaurora.org/cgit/quic/la/platform/frameworks/base/commit/packages/SystemUI/src/com/android/systemui?h=LNX.LA.3.7.2.c5&id=8489b3de7da4efef624bacc6a1d5cf31bd922475

Change-Id: I14176d4cab14bc90198cefd3f4b4880b6d14f566
