### PR TITLE
Only start one WifiClientScanner

### DIFF
--- a/services/java/com/android/server/connectivity/Tethering.java
+++ b/services/java/com/android/server/connectivity/Tethering.java
@@ -132,8 +132,6 @@ public class Tethering extends INetworkManagementEventObserver.Stub {
     private final IConnectivityManager mConnService;
     private Looper mLooper;
 
-    private DoScan mDoScan;
-
     private HashMap<String, TetherInterfaceSM> mIfaces; // all tethered/tetherable ifaces
 
     private BroadcastReceiver mStateReceiver;
@@ -515,15 +513,15 @@ public class Tethering extends INetworkManagementEventObserver.Stub {
             clearTetheredNotification();
         }
 
-        mScanThread = new HandlerThread("WifiClientScanner");
         if (wifiTethered && !bluetoothTethered) {
+            mScanThread = new HandlerThread("WifiClientScanner");
             if (!mScanThread.isAlive()) {
                 mScanThread.start();
                 mScanHandler = new WifiClientScanner(mScanThread.getLooper());
                 mScanHandler.sendEmptyMessage(0);
             }
         } else {
-            if (mScanThread.isAlive()) {
+            if (mScanThread != null && mScanThread.isAlive()) {
                 mScanThread.quit();
             }
         }
@@ -592,8 +590,8 @@ public class Tethering extends INetworkManagementEventObserver.Stub {
 
         @Override
         public void handleMessage(Message msg) {
-            mDoScan = new DoScan();
-            mDoScan.execute();
+            final DoScan doScan = new DoScan();
+            doScan.execute();
             sendEmptyMessageDelayed(0, 2000);
         }
     }


### PR DESCRIPTION
_) Fixes unexpected soft reboots.
E/AndroidRuntime(18586): *_\* FATAL EXCEPTION IN SYSTEM PROCESS: WifiClientScanner
E/AndroidRuntime(18586): java.lang.IllegalStateException: Cannot execute task: the task is already running.
E/AndroidRuntime(18586):     at android.os.AsyncTask.executeOnExecutor(AsyncTask.java:576)
E/AndroidRuntime(18586):     at android.os.AsyncTask.execute(AsyncTask.java:535)
E/AndroidRuntime(18586):     at com.android.server.connectivity.Tethering$WifiClientScanner.handleMessage(Tethering.java:596)
E/AndroidRuntime(18586):     at android.os.Handler.dispatchMessage(Handler.java:102)
E/AndroidRuntime(18586):     at android.os.Looper.loop(Looper.java:136)
E/AndroidRuntime(18586):     at android.os.HandlerThread.run(HandlerThread.java:61)

*) Remove unnecessary mDoScan class member variable.

Change-Id: I17ab368366b9a3456a625974c461783c428efec2
