### PR TITLE
Themes: Fix memory corruption from closing asset before XMLTree

### DIFF
--- a/libs/androidfw/AssetManager.cpp
+++ b/libs/androidfw/AssetManager.cpp
@@ -462,6 +462,7 @@ String8 AssetManager::getPkgName(const char *apkPath) {
 
         }
 
+        tree.uninit();
         manifestAsset->close();
         return pkgName;
     }


### PR DESCRIPTION
Change-Id: Ifa411c18d46f4bb6befa18405ce7daa04de13ccc
