### PR TITLE
Hide msim 'no-sim' icons

### DIFF
--- a/packages/SystemUI/res/layout/msim_signal_cluster_view.xml
+++ b/packages/SystemUI/res/layout/msim_signal_cluster_view.xml
@@ -158,11 +158,6 @@
                 android:layout_width="wrap_content"
                 android:layout_gravity="end|bottom"
                 />
-            <ImageView
-                android:id="@+id/no_sim"
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
-                />
         </FrameLayout>
     </FrameLayout>
     <ImageView
@@ -239,11 +234,6 @@
                 android:layout_width="wrap_content"
                 android:layout_gravity="end|bottom"
                 />
-            <ImageView
-                android:id="@+id/no_sim_slot2"
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
-                />
         </FrameLayout>
     </FrameLayout>
     <ImageView
@@ -319,11 +309,6 @@
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
                 android:layout_gravity="end|bottom"
-                />
-            <ImageView
-                android:id="@+id/no_sim_slot3"
-                android:layout_height="wrap_content"
-                android:layout_width="wrap_content"
                 />
         </FrameLayout>
     </FrameLayout>

--- a/packages/SystemUI/src/com/android/systemui/statusbar/MSimSignalClusterView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/MSimSignalClusterView.java
@@ -75,7 +75,6 @@ public class MSimSignalClusterView
     ViewGroup mWifiGroup;
     ViewGroup[] mMobileGroup;
     ImageView mWifi, mWifiActivity, mAirplane;
-    ImageView[] mNoSimSlot;
     ImageView[] mMobile;
     ImageView[] mMobileRoam;
     ImageView[] mMobileActivity;
@@ -116,7 +115,6 @@ public class MSimSignalClusterView
                                         R.id.mobile_inout_sub3};
     private int[] mMobileTypeResourceId = {R.id.mobile_type, R.id.mobile_type_sub2,
                                          R.id.mobile_type_sub3};
-    private int[] mNoSimSlotResourceId = {R.id.no_sim, R.id.no_sim_slot2, R.id.no_sim_slot3};
     private int[] mDataGroupResourceId = {R.id.data_combo, R.id.data_combo_sub2,
                                         R.id.data_combo_sub3};
     private int[] mDataActResourceId = {R.id.data_inout, R.id.data_inout_sub2,
@@ -146,7 +144,6 @@ public class MSimSignalClusterView
         mMobileActivityId = new int[mNumPhones];
         mNoSimIconId = new int[mNumPhones];
         mMobileGroup = new ViewGroup[mNumPhones];
-        mNoSimSlot = new ImageView[mNumPhones];
         mMobile = new ImageView[mNumPhones];
         mMobileActivity = new ImageView[mNumPhones];
         mMobileRoam = new ImageView[mNumPhones];
@@ -201,7 +198,6 @@ public class MSimSignalClusterView
             mMobileRoam[i]     = (ImageView) findViewById(mMobileRoamResourceId[i]);
             mMobileActivity[i] = (ImageView) findViewById(mMobileActResourceId[i]);
             mMobileType[i]     = (ImageView) findViewById(mMobileTypeResourceId[i]);
-            mNoSimSlot[i]      = (ImageView) findViewById(mNoSimSlotResourceId[i]);
 
             mDataGroup[i]      = (ViewGroup) findViewById(mDataGroupResourceId[i]);
             mDataActivity[i]   = (ImageView) findViewById(mDataActResourceId[i]);
@@ -232,13 +228,12 @@ public class MSimSignalClusterView
         mSpacer         = null;
         mAirplane       = null;
         for (int i = 0; i < mNumPhones; i++) {
-            mMobileGroup[i]    = null;
-            mMobile[i]         = null;
+            mMobileGroup[i] = null;
+            mMobile[i] = null;
             mMobileActivity[i] = null;
-            mMobileType[i]     = null;
-            mNoSimSlot[i]      = null;
-            mDataGroup[i]      = null;
-            mDataActivity[i]   = null;
+            mMobileType[i] = null;
+            mDataGroup[i] = null;
+            mDataActivity[i] = null;
             mMobileDataVoiceGroup[i] = null;
             mMobileSignalData[i] = null;
             mMobileSignalVoice[i] = null;
@@ -416,10 +411,6 @@ public class MSimSignalClusterView
             if (mMobileType[i] != null) {
                 mMobileType[i].setImageDrawable(null);
             }
-            if (mNoSimSlot[i] != null) {
-                mNoSimSlot[i].setImageDrawable(null);
-            }
-
             apply(i);
         }
     }
@@ -441,7 +432,7 @@ public class MSimSignalClusterView
                 String.format("wifi: %s sig=%d act=%d",
                 (mWifiVisible ? "VISIBLE" : "GONE"), mWifiStrengthId, mWifiActivityId));
 
-        if (mMobileVisible && !mIsAirplaneMode) {
+        if ((mMobileVisible && mNoSimIconId[phoneId] == 0) && !mIsAirplaneMode) {
             updateMobile(phoneId);
             updateCdma();
             updateData(phoneId);
@@ -481,10 +472,8 @@ public class MSimSignalClusterView
 
         if (mStyle != STATUS_BAR_STYLE_ANDROID_DEFAULT) {
             if (mNoSimIconId[phoneId] != 0) {
-                mNoSimSlot[phoneId].setVisibility(View.VISIBLE);
                 mMobile[phoneId].setVisibility(View.GONE);
             } else {
-                mNoSimSlot[phoneId].setVisibility(View.GONE);
                 mMobile[phoneId].setVisibility(View.VISIBLE);
             }
         }
@@ -503,10 +492,9 @@ public class MSimSignalClusterView
     private void updateMobile(int phoneId) {
         mMobile[phoneId].setImageResource(mMobileStrengthId[phoneId]);
         mMobileGroup[phoneId].setContentDescription(mMobileTypeDescription + " "
-            + mMobileDescription[phoneId]);
+                + mMobileDescription[phoneId]);
         mMobileActivity[phoneId].setImageResource(mMobileActivityId[phoneId]);
         mMobileType[phoneId].setImageResource(mMobileTypeId[phoneId]);
-        mNoSimSlot[phoneId].setImageResource(mNoSimIconId[phoneId]);
         mMobileRoam[phoneId].setImageResource(mMobileRoamId[phoneId]);
     }
 


### PR DESCRIPTION
Removed all no sim icons which clog up the status bar. When NO sim, the icon
remains hidden.

Change-Id: I218919c8797bcf745fcb6d7b3510478ce37205cd
Signed-off-by: Arvind Mukund armu30@gmail.com
