### PR TITLE
keyguard: dont show enter key when quick unlock is enabled

### DIFF
--- a/packages/Keyguard/src/com/android/keyguard/KeyguardPINView.java
+++ b/packages/Keyguard/src/com/android/keyguard/KeyguardPINView.java
@@ -84,6 +84,10 @@ public class KeyguardPINView extends KeyguardPinBasedInputView {
 
         boolean quickUnlock = (Settings.System.getInt(getContext().getContentResolver(),
                 Settings.System.LOCKSCREEN_QUICK_UNLOCK_CONTROL, 0) == 1);
+        if (quickUnlock) {
+            View v = findViewById(R.id.key_enter);
+            v.setVisibility(View.INVISIBLE);
+        }
 
         boolean scramblePin = (Settings.System.getInt(getContext().getContentResolver(),
                 Settings.System.LOCKSCREEN_PIN_SCRAMBLE_LAYOUT, 0) == 1);


### PR DESCRIPTION
doesn't make sense to show the enter key if the quick unlock is enabled for PIN keyguard
because any tap on it while lead to a invalid pin password

Change-Id: Id79aafb778d1f501d6072b48019752657c8798c4
Signed-off-by: Jorge Ruesga jorge@ruesga.com
